### PR TITLE
[FEAT] Add Editable Question Options with Delete Functionality and TextButton Size Variants

### DIFF
--- a/src/app/forms/[id]/edit/page.tsx
+++ b/src/app/forms/[id]/edit/page.tsx
@@ -1,34 +1,49 @@
-"use client"
-import { useEffect, useState } from 'react'
-import { useParams, useRouter } from 'next/navigation'
-import { getFormQuestions, updateForm, addQuestion, addQuestionOption, updateQuestion } from '@/lib/supabase/forms'
-import { supabase } from '@/lib/supabase/client'
+"use client";
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import {
+  getFormQuestions,
+  updateForm,
+  addQuestion,
+  addQuestionOption,
+  updateQuestion,
+  updateQuestionOption,
+  deleteQuestionOption,
+} from "@/lib/supabase/forms";
+import { supabase } from "@/lib/supabase/client";
+import TextButton from "@/components/ui/TextButton";
 
 export default function EditFormPage() {
-  const params = useParams() as { id: string }
-  const router = useRouter()
-  const [form, setForm] = useState<any>(null)
-  const [questions, setQuestions] = useState<any[]>([])
-  const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
+  const params = useParams() as { id: string };
+  const router = useRouter();
+  const [form, setForm] = useState<any>(null);
+  const [questions, setQuestions] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    let mounted = true
-    ;(async () => {
-      const { data: formData } = await supabase.from('forms').select('*').eq('id', params.id).single()
-      const { data: qs } = await getFormQuestions(params.id)
+    let mounted = true;
+    (async () => {
+      const { data: formData } = await supabase
+        .from("forms")
+        .select("*")
+        .eq("id", params.id)
+        .single();
+      const { data: qs } = await getFormQuestions(params.id);
       if (mounted) {
-        setForm(formData)
-        setQuestions(qs || [])
-        setLoading(false)
+        setForm(formData);
+        setQuestions(qs || []);
+        setLoading(false);
       }
-    })()
-    return () => { mounted = false }
-  }, [params.id])
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [params.id]);
 
   async function onMetaSave(e: React.FormEvent) {
-    e.preventDefault()
-    setSaving(true)
+    e.preventDefault();
+    setSaving(true);
     const { data, error } = await updateForm(form.id, {
       title: form.title,
       description: form.description,
@@ -41,36 +56,83 @@ export default function EditFormPage() {
       end_at: form.end_at,
       email_notify_on_new_response: form.email_notify_on_new_response,
       email_summary_frequency: form.email_summary_frequency,
-      collect_submitter_email: form.collect_submitter_email
-    } as any)
-    setSaving(false)
-    if (error) alert(error.message)
-    if (data) setForm(data)
+      collect_submitter_email: form.collect_submitter_email,
+    } as any);
+    setSaving(false);
+    if (error) alert(error.message);
+    if (data) setForm(data);
   }
 
   async function onAddQuestion(type: any) {
-    const { data, error } = await addQuestion(form.id, { type, label: 'Untitled question', order_index: questions.length })
-    if (error) { alert(error.message); return }
-    if (data) setQuestions(prev => [...prev, data])
+    const { data, error } = await addQuestion(form.id, {
+      type,
+      label: "Untitled question",
+      order_index: questions.length,
+    });
+    if (error) {
+      alert(error.message);
+      return;
+    }
+    if (data) setQuestions((prev) => [...prev, data]);
   }
 
   async function onAddOption(qId: string) {
-    const q = questions.find(q => q.id === qId)
-    const { data, error } = await addQuestionOption(qId, { label: `Option ${(q?.options?.length || 0) + 1}` })
-    if (error) { alert(error.message); return }
-    setQuestions(prev => prev.map(item => item.id === qId ? { ...item, options: [...(item.options||[]), data] } : item))
+    const q = questions.find((q) => q.id === qId);
+    const { data, error } = await addQuestionOption(qId, {
+      label: `Option ${(q?.options?.length || 0) + 1}`,
+    });
+    if (error) {
+      alert(error.message);
+      return;
+    }
+    setQuestions((prev) =>
+      prev.map((item) =>
+        item.id === qId
+          ? { ...item, options: [...(item.options || []), data] }
+          : item
+      )
+    );
   }
 
-  if (loading) return <div className="p-4">Loading…</div>
-  if (!form) return <div className="p-4">Form not found</div>
+  async function onDeleteOption(optionId: string, questionId: string) {
+    const { error } = await deleteQuestionOption(optionId);
+    if (error) {
+      alert(error.message);
+      return;
+    }
+    setQuestions((prev) =>
+      prev.map((item) =>
+        item.id === questionId
+          ? {
+              ...item,
+              options:
+                item.options?.filter((opt: any) => opt.id !== optionId) || [],
+            }
+          : item
+      )
+    );
+  }
+
+  if (loading) return <div className="p-4">Loading…</div>;
+  if (!form) return <div className="p-4">Form not found</div>;
 
   return (
     <div className="max-w-6xl mx-auto p-4 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Edit Form</h1>
         <div className="flex gap-2">
-          <button className="px-3 py-2 border rounded" onClick={() => router.push(`/f/${form.slug}`)}>Preview</button>
-          <button className="px-3 py-2 border rounded" onClick={() => router.push('/forms')}>Back</button>
+          <button
+            className="px-3 py-2 border rounded"
+            onClick={() => router.push(`/f/${form.slug}`)}
+          >
+            Preview
+          </button>
+          <button
+            className="px-3 py-2 border rounded"
+            onClick={() => router.push("/forms")}
+          >
+            Back
+          </button>
         </div>
       </div>
 
@@ -78,19 +140,48 @@ export default function EditFormPage() {
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1">Title</label>
-            <input className="border rounded w-full px-3 py-2" value={form.title || ''} onChange={e=>setForm((f:any)=>({...f, title:e.target.value}))} required />
+            <input
+              className="border rounded w-full px-3 py-2"
+              value={form.title || ""}
+              onChange={(e) =>
+                setForm((f: any) => ({ ...f, title: e.target.value }))
+              }
+              required
+            />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Description</label>
-            <textarea className="border rounded w-full px-3 py-2" value={form.description||''} onChange={e=>setForm((f:any)=>({...f, description:e.target.value}))} rows={3} />
+            <label className="block text-sm font-medium mb-1">
+              Description
+            </label>
+            <textarea
+              className="border rounded w-full px-3 py-2"
+              value={form.description || ""}
+              onChange={(e) =>
+                setForm((f: any) => ({ ...f, description: e.target.value }))
+              }
+              rows={3}
+            />
           </div>
           <div className="flex items-center gap-2">
-            <input id="internal" type="checkbox" checked={!!form.is_internal} onChange={e=>setForm((f:any)=>({...f, is_internal:e.target.checked}))} />
+            <input
+              id="internal"
+              type="checkbox"
+              checked={!!form.is_internal}
+              onChange={(e) =>
+                setForm((f: any) => ({ ...f, is_internal: e.target.checked }))
+              }
+            />
             <label htmlFor="internal">Internal Only</label>
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Status</label>
-            <select className="border rounded w-full px-3 py-2" value={form.status} onChange={e=>setForm((f:any)=>({...f, status:e.target.value}))}>
+            <select
+              className="border rounded w-full px-3 py-2"
+              value={form.status}
+              onChange={(e) =>
+                setForm((f: any) => ({ ...f, status: e.target.value }))
+              }
+            >
               <option value="inactive">Inactive</option>
               <option value="active">Active</option>
               <option value="closed">Closed</option>
@@ -99,35 +190,119 @@ export default function EditFormPage() {
           <div className="grid grid-cols-2 gap-2">
             <div>
               <label className="block text-sm font-medium mb-1">Start At</label>
-              <input type="datetime-local" className="border rounded w-full px-3 py-2" value={form.start_at ? new Date(form.start_at).toISOString().slice(0,16) : ''} onChange={e=>setForm((f:any)=>({...f, start_at:e.target.value ? new Date(e.target.value).toISOString() : null}))} />
+              <input
+                type="datetime-local"
+                className="border rounded w-full px-3 py-2"
+                value={
+                  form.start_at
+                    ? new Date(form.start_at).toISOString().slice(0, 16)
+                    : ""
+                }
+                onChange={(e) =>
+                  setForm((f: any) => ({
+                    ...f,
+                    start_at: e.target.value
+                      ? new Date(e.target.value).toISOString()
+                      : null,
+                  }))
+                }
+              />
             </div>
             <div>
               <label className="block text-sm font-medium mb-1">End At</label>
-              <input type="datetime-local" className="border rounded w-full px-3 py-2" value={form.end_at ? new Date(form.end_at).toISOString().slice(0,16) : ''} onChange={e=>setForm((f:any)=>({...f, end_at:e.target.value ? new Date(e.target.value).toISOString() : null}))} />
+              <input
+                type="datetime-local"
+                className="border rounded w-full px-3 py-2"
+                value={
+                  form.end_at
+                    ? new Date(form.end_at).toISOString().slice(0, 16)
+                    : ""
+                }
+                onChange={(e) =>
+                  setForm((f: any) => ({
+                    ...f,
+                    end_at: e.target.value
+                      ? new Date(e.target.value).toISOString()
+                      : null,
+                  }))
+                }
+              />
             </div>
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Submission Limit</label>
-            <input type="number" min={1} className="border rounded w-full px-3 py-2" value={form.submission_limit||''} onChange={e=>setForm((f:any)=>({...f, submission_limit:e.target.value ? Number(e.target.value) : null}))} />
+            <label className="block text-sm font-medium mb-1">
+              Submission Limit
+            </label>
+            <input
+              type="number"
+              min={1}
+              className="border rounded w-full px-3 py-2"
+              value={form.submission_limit || ""}
+              onChange={(e) =>
+                setForm((f: any) => ({
+                  ...f,
+                  submission_limit: e.target.value
+                    ? Number(e.target.value)
+                    : null,
+                }))
+              }
+            />
           </div>
           <div className="flex items-center gap-2">
-            <input id="notify" type="checkbox" checked={!!form.email_notify_on_new_response} onChange={e=>setForm((f:any)=>({...f, email_notify_on_new_response:e.target.checked}))} />
+            <input
+              id="notify"
+              type="checkbox"
+              checked={!!form.email_notify_on_new_response}
+              onChange={(e) =>
+                setForm((f: any) => ({
+                  ...f,
+                  email_notify_on_new_response: e.target.checked,
+                }))
+              }
+            />
             <label htmlFor="notify">Email notify on new response</label>
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Summary Frequency</label>
-            <select className="border rounded w-full px-3 py-2" value={form.email_summary_frequency||'none'} onChange={e=>setForm((f:any)=>({...f, email_summary_frequency:e.target.value}))}>
+            <label className="block text-sm font-medium mb-1">
+              Summary Frequency
+            </label>
+            <select
+              className="border rounded w-full px-3 py-2"
+              value={form.email_summary_frequency || "none"}
+              onChange={(e) =>
+                setForm((f: any) => ({
+                  ...f,
+                  email_summary_frequency: e.target.value,
+                }))
+              }
+            >
               <option value="none">None</option>
               <option value="daily">Daily</option>
               <option value="weekly">Weekly</option>
             </select>
           </div>
           <div className="flex items-center gap-2">
-            <input id="collect" type="checkbox" checked={!!form.collect_submitter_email} onChange={e=>setForm((f:any)=>({...f, collect_submitter_email:e.target.checked}))} />
+            <input
+              id="collect"
+              type="checkbox"
+              checked={!!form.collect_submitter_email}
+              onChange={(e) =>
+                setForm((f: any) => ({
+                  ...f,
+                  collect_submitter_email: e.target.checked,
+                }))
+              }
+            />
             <label htmlFor="collect">Collect submitter email</label>
           </div>
           <div className="flex gap-2">
-            <button type="submit" className="px-3 py-2 border rounded" disabled={saving}>{saving ? 'Saving…' : 'Save Settings'}</button>
+            <button
+              type="submit"
+              className="px-3 py-2 border rounded"
+              disabled={saving}
+            >
+              {saving ? "Saving…" : "Save Settings"}
+            </button>
           </div>
         </div>
 
@@ -135,8 +310,15 @@ export default function EditFormPage() {
           <div className="flex items-center justify-between">
             <h2 className="font-medium">Questions</h2>
             <div className="flex gap-2">
-              <select id="add-type" className="border rounded px-2 py-1" onChange={()=>{}} defaultValue="">
-                <option value="" disabled>Choose type</option>
+              <select
+                id="add-type"
+                className="border rounded px-2 py-1"
+                onChange={() => {}}
+                defaultValue=""
+              >
+                <option value="" disabled>
+                  Choose type
+                </option>
                 <option value="short_text">Short Text</option>
                 <option value="long_text">Long Text</option>
                 <option value="multiple_choice">Multiple Choice</option>
@@ -149,59 +331,139 @@ export default function EditFormPage() {
                 <option value="number">Number</option>
                 <option value="file_upload">File Upload</option>
               </select>
-              <button className="px-3 py-2 border rounded" onClick={() => {
-                const sel = (document.getElementById('add-type') as HTMLSelectElement)
-                if (!sel || !sel.value) return
-                onAddQuestion(sel.value)
-                sel.value = ''
-              }}>Add Question</button>
+              <button
+                className="px-3 py-2 border rounded"
+                onClick={() => {
+                  const sel = document.getElementById(
+                    "add-type"
+                  ) as HTMLSelectElement;
+                  if (!sel || !sel.value) return;
+                  onAddQuestion(sel.value);
+                  sel.value = "";
+                }}
+              >
+                Add Question
+              </button>
             </div>
           </div>
           <div className="space-y-3">
             {questions.map((q) => (
               <div key={q.id} className="border rounded p-3">
                 <div className="flex items-center justify-between">
-                  <span className="text-xs uppercase text-gray-500">{q.type}</span>
+                  <span className="text-xs uppercase text-gray-500">
+                    {q.type}
+                  </span>
                 </div>
-                <input className="mt-2 border rounded w-full px-3 py-2" value={q.label} onChange={e=>setQuestions(prev=>prev.map(i=>i.id===q.id?{...i,label:e.target.value}:i))} onBlur={async()=>{
-                  const cur = questions.find(i=>i.id===q.id)
-                  if (cur) await updateQuestion(q.id, { label: cur.label })
-                }} />
+                <input
+                  className="mt-2 border rounded w-full px-3 py-2"
+                  value={q.label}
+                  onChange={(e) =>
+                    setQuestions((prev) =>
+                      prev.map((i) =>
+                        i.id === q.id ? { ...i, label: e.target.value } : i
+                      )
+                    )
+                  }
+                  onBlur={async () => {
+                    const cur = questions.find((i) => i.id === q.id);
+                    if (cur) await updateQuestion(q.id, { label: cur.label });
+                  }}
+                />
                 <div className="mt-2 flex items-center gap-2">
-                  <input id={`req-${q.id}`} type="checkbox" checked={!!q.required} onChange={async e=>{
-                    const checked = e.target.checked
-                    setQuestions(prev=>prev.map(i=>i.id===q.id?{...i,required:checked}:i))
-                    await updateQuestion(q.id, { required: checked })
-                  }} />
+                  <input
+                    id={`req-${q.id}`}
+                    type="checkbox"
+                    checked={!!q.required}
+                    onChange={async (e) => {
+                      const checked = e.target.checked;
+                      setQuestions((prev) =>
+                        prev.map((i) =>
+                          i.id === q.id ? { ...i, required: checked } : i
+                        )
+                      );
+                      await updateQuestion(q.id, { required: checked });
+                    }}
+                  />
                   <label htmlFor={`req-${q.id}`}>Required</label>
                 </div>
-                {['multiple_choice','checkboxes','dropdown'].includes(q.type) && (
+                {["multiple_choice", "checkboxes", "dropdown"].includes(
+                  q.type
+                ) && (
                   <div className="mt-3 space-y-2">
                     <div className="flex items-center justify-between">
                       <span className="text-sm font-medium">Options</span>
-                      <button className="px-2 py-1 border rounded text-sm" onClick={() => onAddOption(q.id)}>Add option</button>
+                      <button
+                        className="px-2 py-1 border rounded text-sm"
+                        onClick={() => onAddOption(q.id)}
+                      >
+                        Add option
+                      </button>
                     </div>
                     <ul className="space-y-1">
-                      {(q.options||[]).map((o:any) => (
+                      {(q.options || []).map((o: any) => (
                         <li key={o.id} className="flex items-center gap-2">
-                          <span className="text-xs text-gray-500">{o.order_index+1}.</span>
-                          <span>{o.label}</span>
+                          <span className="text-xs text-gray-500">
+                            {o.order_index + 1}.
+                          </span>
+                          <input
+                            className="border rounded px-2 py-1 flex-1 text-sm"
+                            value={o.label}
+                            onChange={(e) => {
+                              setQuestions((prev) =>
+                                prev.map((item) =>
+                                  item.id === q.id
+                                    ? {
+                                        ...item,
+                                        options: item.options?.map((opt: any) =>
+                                          opt.id === o.id
+                                            ? { ...opt, label: e.target.value }
+                                            : opt
+                                        ),
+                                      }
+                                    : item
+                                )
+                              );
+                            }}
+                            onBlur={async () => {
+                              const currentOption = questions
+                                .find((item) => item.id === q.id)
+                                ?.options?.find((opt: any) => opt.id === o.id);
+                              if (currentOption) {
+                                const { error } = await updateQuestionOption(
+                                  o.id,
+                                  { label: currentOption.label }
+                                );
+                                if (error) alert(error.message);
+                              }
+                            }}
+                          />
+                          <TextButton
+                            onClick={() => onDeleteOption(o.id, q.id)}
+                            variant="error"
+                            size="small"
+                          >
+                            ×
+                          </TextButton>
                         </li>
                       ))}
-                      {(q.options||[]).length === 0 && <li className="text-xs text-gray-500">No options yet</li>}
+                      {(q.options || []).length === 0 && (
+                        <li className="text-xs text-gray-500">
+                          No options yet
+                        </li>
+                      )}
                     </ul>
                   </div>
                 )}
               </div>
             ))}
             {questions.length === 0 && (
-              <div className="text-sm text-gray-500">No questions yet. Add your first question.</div>
+              <div className="text-sm text-gray-500">
+                No questions yet. Add your first question.
+              </div>
             )}
           </div>
         </div>
       </form>
     </div>
-  )
+  );
 }
-
-

--- a/src/components/ui/TextButton.tsx
+++ b/src/components/ui/TextButton.tsx
@@ -2,6 +2,7 @@ interface TextButtonProps {
   children: React.ReactNode
   onClick?: () => void
   variant?: 'default' | 'success' | 'warning' | 'error'
+  size?: 'default' | 'small'
   disabled?: boolean
   type?: 'button' | 'submit' | 'reset'
   className?: string
@@ -11,6 +12,7 @@ export default function TextButton({
   children, 
   onClick, 
   variant = 'default', 
+  size = 'default',
   disabled = false,
   type = 'button',
   className = '' 
@@ -22,6 +24,11 @@ export default function TextButton({
     error: 'error'
   }
 
+  const sizeClasses = {
+    default: 'px-4 py-2 text-sm',
+    small: 'px-2 py-1 text-xs'
+  }
+
   const disabledClasses = disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
 
   return (
@@ -30,9 +37,9 @@ export default function TextButton({
       onClick={onClick}
       disabled={disabled}
       className={`
-        inline-block px-4 py-2 border font-mono font-medium
-        transition-colors duration-200 text-sm uppercase tracking-wide
-        ${variantClasses[variant]} ${disabledClasses} ${className}
+        inline-block border font-mono font-medium
+        transition-colors duration-200 uppercase tracking-wide
+        ${sizeClasses[size]} ${variantClasses[variant]} ${disabledClasses} ${className}
       `}
     >
       {children}

--- a/src/lib/supabase/forms.ts
+++ b/src/lib/supabase/forms.ts
@@ -161,10 +161,10 @@ export async function getFormQuestions(formId: string) {
   if (optErr) return { data: null, error: optErr }
 
   const optionsByQ = new Map<string, FormQuestionOption[]>()
-  ;(options || []).forEach((o: any) => {
-    const prev = optionsByQ.get(o.question_id) || []
-    optionsByQ.set(o.question_id, [...prev, o])
-  })
+    ; (options || []).forEach((o: any) => {
+      const prev = optionsByQ.get(o.question_id) || []
+      optionsByQ.set(o.question_id, [...prev, o])
+    })
 
   const merged = (questions || []).map((q: any) => ({
     ...q,
@@ -273,6 +273,31 @@ export async function updateQuestion(questionId: string, updates: Partial<FormQu
     .single()
   if (error) return { data: null, error }
   return { data, error: null }
+}
+
+export async function updateQuestionOption(optionId: string, updates: Partial<FormQuestionOption>) {
+  const payload: any = {}
+  if (typeof updates.label !== 'undefined') payload.label = updates.label
+  if (typeof updates.value !== 'undefined') payload.value = updates.value
+  if (typeof updates.order_index !== 'undefined') payload.order_index = updates.order_index
+  if (typeof updates.is_other !== 'undefined') payload.is_other = updates.is_other
+
+  const { data, error } = await supabase
+    .from('form_question_options')
+    .update(payload)
+    .eq('id', optionId)
+    .select('*')
+    .single()
+  if (error) return { data: null, error }
+  return { data: data as FormQuestionOption, error: null }
+}
+
+export async function deleteQuestionOption(optionId: string) {
+  const { error } = await supabase
+    .from('form_question_options')
+    .delete()
+    .eq('id', optionId)
+  return { error: error || null }
 }
 
 


### PR DESCRIPTION
## Description
This PR introduces editable question options functionality to the form builder with delete capabilities, and enhances the TextButton component with size variants for better UI consistency.

### Editable Question Options
- **Inline editing**: Click on option labels to edit them directly with auto-save on blur
- **Delete functionality**: Remove individual options using styled delete buttons

### TextButton Component Enhancement
- **Size variants**: Added `small` and `default` size options

### Supabase API Integration
- **updateQuestionOption**: Updates option properties (label, value, order_index, is_other)
- **deleteQuestionOption**: Safely removes options from database

## Impact
- **Enhanced Form UX**: Users can now edit and delete form options
- **Developer experience**: Reusable TextButton size variants for other components

## Steps to Test
1. **Navigate to Forms Edit page**: Go to `/forms/[id]/edit` for any existing form
2. **Test option editing**: Click on any option label in Multiple Choice or Dropdown questions
3. **Verify auto-save**: Edit option text and click away - changes should persist
4. **Test delete functionality**: Click the red × button next to any option
6. **Verify UI consistency**: Ensure delete buttons match project's error button styling
7. **Add new options**: Use "Add option" button and verify new options are editable